### PR TITLE
POST multiple elements

### DIFF
--- a/src/collections/models.py
+++ b/src/collections/models.py
@@ -20,8 +20,7 @@ class CollectionObject(Model):
         self.id = id or 'http://example.org/mem/'+str(randint(100000, 999999)) # todo: make parsing safe and id minting formalized, e.g. give Service Object a function
         self.capabilities = capabilities if isinstance(capabilities, CollectionCapabilities) else CollectionCapabilities(**capabilities)
         self.properties = properties if isinstance(properties, CollectionProperties) else CollectionProperties(**properties)
-        if description:
-            self.description = description
+        self.description = description
 
 
 class CollectionCapabilities(Model):

--- a/src/members/views.py
+++ b/src/members/views.py
@@ -82,7 +82,7 @@ class MemberView(MethodView):
             # todo: check if ids are currently in use
 
 
-            res = app.db.find_member(id, [o.id for o in obj])
+            res = app.db.ask_member(id, [o.id for o in obj])
             if res>0:
                 raise ConflictError()
             #if profile:
@@ -95,7 +95,7 @@ class MemberView(MethodView):
 
 
             return jsonify(app.db.get_member(id, [o.id for o in obj])), 201
-        except (NotFoundError, DBError, UnauthorizedError, ForbiddenError):
+        except (NotFoundError, DBError, UnauthorizedError, ForbiddenError, ConflictError):
             raise
         except:
             raise ParseError()

--- a/src/members/views.py
+++ b/src/members/views.py
@@ -70,6 +70,8 @@ class MemberView(MethodView):
             if not id:
                 raise NotFoundError()
             obj = json.loads(request.data)
+            if not isinstance(obj, list):
+                obj=[obj]
             # todo: raise parseError if
             #if not isinstance(obj, Model):
             #    if app.db.get_service().providesCollectionPids:

--- a/src/utils/conversions/rda.py
+++ b/src/utils/conversions/rda.py
@@ -85,6 +85,8 @@ class RDATools:
             elif obj == RDF.nil:
                 key = propertiesMap.get(str(prd),{'label':str(prd).replace(str(node)+"@","")}).get('label')
                 dct.update({key: []})
+            elif prd == RDF.type and obj == RDA.Empty:
+                dct.update({})
             elif str(prd) in propertiesMap or propertiesMap == {}:
                 key = propertiesMap.get(str(prd),{'label':str(prd).replace(str(node)+"@","")}).get('label')
                 value = propertiesMap.get(str(prd),{'type':str}).get('type')(obj)
@@ -113,6 +115,9 @@ class RDATools:
         elif isinstance(val, dict):
             if not subject:
                 subject = g.identifier
+            items = [(k,v) for k,v in val.items() if not k.startswith("__")]
+            if len(items) is 0:
+                g.add((subject,URIRef(map.get(key, {'label': RDF.type})['label']), RDA.Empty))
             for k,v in [(k,v) for k,v in val.items() if not k.startswith("__")]:
                 if isinstance(v, list):
                     self.dict_to_graph(v, key=k, subject=subject, map=map, g=g) # same subject, map

--- a/src/utils/data/db.py
+++ b/src/utils/data/db.py
@@ -1,48 +1,148 @@
 import abc
 
+class DBMeta(abc.ABCMeta):
+    def __new__(mcls, classname, bases, cls_dict):
+        cls = super().__new__(mcls, classname, bases, cls_dict)
+        for name, member in cls_dict.items():
+            if not getattr(member, '__doc__'):
+                member.__doc__ = getattr(bases[-1], name).__doc__ if hasattr(bases[-1], name) else None
+        return cls
 
-class DBInterface(object, metaclass=abc.ABCMeta):
+class DBInterface(object, metaclass=DBMeta):
+
+    @abc.abstractmethod
+    def ask_collection(self, id):
+        """
+        Check for existence of Collections
+
+        :param id: An ID or list of IDs
+        :return: A value between 0 and 1 - 0=none, 0.x=some, 1=all
+        """
+        pass
 
     @abc.abstractmethod
     def get_collection(self, id=None):
+        """
+        Retrieve Collection data
+
+        :param id: An ID, a list of IDs or nothing (returns all)
+        :return: A list of Collection objects
+        """
         pass
 
     @abc.abstractmethod
     def set_collection(self, c_obj):
+        """
+        Store Collection data
+
+        :param c_obj: A Collection object or a list of Collection objects
+        :return:
+        """
         pass
 
     @abc.abstractmethod
     def del_collection(self, id):
+        """
+        Delete Collection data
+
+        :param id: A collection ID
+        :return:
+        """
         pass
 
     @abc.abstractmethod
     def upd_collection(self, c_obj):
+        """
+        Update Collection data
+
+        :param c_obj: A Collection object with an existing ID
+        :return:
+        """
+        pass
+
+
+
+    @abc.abstractmethod
+    def ask_member(self, cid, mid):
+        """
+        Check for existence of MemberItems
+
+        :param cid: A collection id
+        :param mid: An ID or list of IDs
+        :return: A value between 0 and 1 - 0=none, 0.x=some, 1=all
+        """
         pass
 
     @abc.abstractmethod
-    def get_member(self, id=None):
+    def get_member(self, cid, mid=None):
+        """
+        Retrieve Member data
+
+        :param cid: A Collection ID
+        :param mid: An ID, a list of IDs or nothing
+        :return: A list of MemberItem objects
+        """
         pass
 
     @abc.abstractmethod
     def set_member(self, c_id, m_obj):
+        """
+        Store MemberItem data
+
+        :param c_id: A Collection ID
+        :param m_obj: A MemberItem object or list of MemberItem objects
+        :return:
+        """
         pass
 
     @abc.abstractmethod
     def del_member(self, c_id, m_id):
+        """
+        Delete MemberItem data
+
+        :param c_id: A Collection ID
+        :param m_id: An ID or list of IDs
+        :return:
+        """
         pass
 
     @abc.abstractmethod
     def upd_member(self, c_id, m_obj):
+        """
+        Update MemberItem data
+
+        :param c_id: A Collection ID
+        :param m_obj: A MemberItem object with an existing ID
+        :return:
+        """
         pass
+
+
 
     @abc.abstractmethod
     def get_service(self):
+        """
+
+        :return:
+        """
         pass
 
     @abc.abstractmethod
     def set_service(self, s_obj):
+        """
+
+        :param s_obj:
+        :return:
+        """
         pass
+
+
 
     @abc.abstractmethod
     def get_id(self, type):
+        """
+
+        :param type:
+        :return:
+        """
         pass

--- a/src/utils/data/db.py
+++ b/src/utils/data/db.py
@@ -11,7 +11,7 @@ class DBMeta(abc.ABCMeta):
 class DBInterface(object, metaclass=DBMeta):
 
     @abc.abstractmethod
-    def ask_collection(self, id):
+    def ask_collection(self, c_id):
         """
         Check for existence of Collections
 
@@ -21,7 +21,7 @@ class DBInterface(object, metaclass=DBMeta):
         pass
 
     @abc.abstractmethod
-    def get_collection(self, id=None):
+    def get_collection(self, c_id=None):
         """
         Retrieve Collection data
 
@@ -41,7 +41,7 @@ class DBInterface(object, metaclass=DBMeta):
         pass
 
     @abc.abstractmethod
-    def del_collection(self, id):
+    def del_collection(self, c_id):
         """
         Delete Collection data
 
@@ -63,7 +63,7 @@ class DBInterface(object, metaclass=DBMeta):
 
 
     @abc.abstractmethod
-    def ask_member(self, cid, mid):
+    def ask_member(self, c_id, m_id):
         """
         Check for existence of MemberItems
 
@@ -74,7 +74,7 @@ class DBInterface(object, metaclass=DBMeta):
         pass
 
     @abc.abstractmethod
-    def get_member(self, cid, mid=None):
+    def get_member(self, c_id, m_id=None):
         """
         Retrieve Member data
 
@@ -139,10 +139,10 @@ class DBInterface(object, metaclass=DBMeta):
 
 
     @abc.abstractmethod
-    def get_id(self, type):
+    def get_id(self, type_class):
         """
 
-        :param type:
+        :param type_class:
         :return:
         """
         pass

--- a/src/utils/data/filesystem_db.py
+++ b/src/utils/data/filesystem_db.py
@@ -35,6 +35,12 @@ class FilesystemDB(DBInterface):
         except:
             raise DBError()
 
+    def ask_collection(self, id):
+        pass
+
+    def ask_member(self, id):
+        pass
+
     def get_collection(self, cid=None):
         if cid is None:
             ids = [d for d in listdir(self.d_data) if isdir(join(self.d_data, d))]

--- a/src/utils/data/filesystem_db.py
+++ b/src/utils/data/filesystem_db.py
@@ -35,34 +35,34 @@ class FilesystemDB(DBInterface):
         except:
             raise DBError()
 
-    def ask_collection(self, id):
+    def ask_collection(self, c_id):
         pass
 
-    def ask_member(self, id):
+    def ask_member(self, c_id, m_id):
         pass
 
-    def get_collection(self, cid=None):
-        if cid is None:
+    def get_collection(self, c_id=None):
+        if c_id is None:
             ids = [d for d in listdir(self.d_data) if isdir(join(self.d_data, d))]
             return self.get_collection(ids)
         else:
-            if not type(cid) in (type([]), type(()), type(set())):
-                cid = [cid]
-            result = [self.__load_json__(join(self.d_data, id.replace('/', '∕'), self.d_collection)) for id in cid]
+            if not type(c_id) in (type([]), type(()), type(set())):
+                c_id = [c_id]
+            result = [self.__load_json__(join(self.d_data, id.replace('/', '∕'), self.d_collection)) for id in c_id]
             return [c for c in result if c is not None]
 
     '''
         @:returns CollectionObject or Error
     '''
-    def set_collection(self,cObject):
-        filename = join(self.d_data, cObject.id.replace('/', '∕'), self.d_collection)
-        self.__write_json__(filename, cObject)
-        return cObject
+    def set_collection(self, c_obj):
+        filename = join(self.d_data, c_obj.id.replace('/', '∕'), self.d_collection)
+        self.__write_json__(filename, c_obj)
+        return c_obj
 
 
-    def del_collection(self, cid):
+    def del_collection(self, c_id):
         try:
-            filename = join(self.d_data, cid.replace('/', '∕'))
+            filename = join(self.d_data, c_id.replace('/', '∕'))
             rmtree(filename)
             return True
         except FileNotFoundError:
@@ -75,22 +75,22 @@ class FilesystemDB(DBInterface):
         self.set_collection(c_obj)
         return c_obj
 
-    def get_member(self, cid, mid=None):
-        if mid is None:
-            return self.get_member(cid, [m[:-5] for m in listdir(join(self.d_data, cid.replace('/', '∕'))) if (m.endswith('.json') and m != self.d_collection)])
+    def get_member(self, c_id, m_id=None):
+        if m_id is None:
+            return self.get_member(c_id, [m[:-5] for m in listdir(join(self.d_data, c_id.replace('/', '∕'))) if (m.endswith('.json') and m != self.d_collection)])
         else:
-            if not type(mid) in (type([]), type(()), type(set())):
-                mid = [mid]
-            return [self.__load_json__(join(self.d_data, cid.replace('/', '∕'), id.replace('/', '∕')+'.json')) for id in mid]
+            if not type(m_id) in (type([]), type(()), type(set())):
+                m_id = [m_id]
+            return [self.__load_json__(join(self.d_data, c_id.replace('/', '∕'), id.replace('/', '∕')+'.json')) for id in m_id]
 
-    def set_member(self, cid, mObject):
-        filename = join(self.d_data, cid.replace('/', '∕'), mObject.id.replace('/', '∕')+'.json')
-        self.__write_json__(filename, mObject)
-        return mObject
+    def set_member(self, c_id, m_obj):
+        filename = join(self.d_data, c_id.replace('/', '∕'), m_obj.id.replace('/', '∕')+'.json')
+        self.__write_json__(filename, m_obj)
+        return m_obj
 
-    def del_member(self, cid, mid):
+    def del_member(self, c_id, m_id):
         try:
-            filename = join(self.d_data, cid.replace('/', '∕'), mid.replace('/', '∕')+'.json')
+            filename = join(self.d_data, c_id.replace('/', '∕'), m_id.replace('/', '∕')+'.json')
             remove(filename)
             return True
         except FileNotFoundError:
@@ -98,16 +98,16 @@ class FilesystemDB(DBInterface):
         except:
             raise DBError()
 
-    def upd_member(self, cid, m_obj):
-        self.del_member(cid, m_obj.id)
-        self.set_member(cid, m_obj)
+    def upd_member(self, c_id, m_obj):
+        self.del_member(c_id, m_obj.id)
+        self.set_member(c_id, m_obj)
         return m_obj
 
     def get_service(self):
         return self.__load_json__(join(self.d_data, self.d_service))
 
-    def set_service(self, sObject):
-        self.__write_json__(join(self.d_data, self.d_service), sObject)
+    def set_service(self, s_obj):
+        self.__write_json__(join(self.d_data, self.d_service), s_obj)
 
 
     def get_id(self, type_class):

--- a/src/utils/data/ldp_db.py
+++ b/src/utils/data/ldp_db.py
@@ -202,8 +202,7 @@ class LDPDataBase(DBInterface):
         service += self.RDA.service_to_graph(s_obj)
         ldp = ds.graph(identifier=LDP.ns)
         ldp += LDP.add_contains(self.marmotta.ldp(),service.identifier,False)
-        insert = self.sparql.service.insert(ds)
-        response = requests.post(self.marmotta.sparql.update, data=insert)
+        response = self.sparql.insert(ds)
         if response.status_code is 200:
             return s_obj
         else:

--- a/src/utils/data/ldp_db.py
+++ b/src/utils/data/ldp_db.py
@@ -37,18 +37,18 @@ class LDPDataBase(DBInterface):
         self.sparql = SPARQLTools(self.marmotta.sparql)
         self.RDA = RDATools(self.marmotta)
 
-    def ask_collection(self, cid):
-        if not isinstance(cid, list):
-            cid = [cid]
-        ids = [self.marmotta.ldp(encoder.encode(id)) for id in cid]
+    def ask_collection(self, c_id):
+        if not isinstance(c_id, list):
+            c_id = [c_id]
+        ids = [self.marmotta.ldp(encoder.encode(id)) for id in c_id]
         result = self.sparql.find(ids,self.RDA.ns.Collection)
-        return float(result.bindings.pop().get(Variable('size')))/len(cid)
+        return float(result.bindings.pop().get(Variable('size')))/len(c_id)
 
-    def get_collection(self, id=None):
+    def get_collection(self, c_id=None):
         # todo: ASK and check if collection exists
-        if id is not None:
-            result = self.sparql.select(self.marmotta.ldp(encoder.encode(id)))
-            graph = result.toDataset().graph(self.marmotta.ldp(encoder.encode(id)))
+        if c_id is not None:
+            result = self.sparql.select(self.marmotta.ldp(encoder.encode(c_id)))
+            graph = result.toDataset().graph(self.marmotta.ldp(encoder.encode(c_id)))
             contents = self.RDA.graph_to_collection(graph)
             if len(contents) is 0:
                 raise NotFoundError()
@@ -83,9 +83,9 @@ class LDPDataBase(DBInterface):
         else:
             raise DBError()
 
-    def del_collection(self, id):
-        if self.sparql.ask(self.marmotta.ldp(encoder.encode(id)), self.RDA.ns.Collection).askAnswer:
-            self.sparql.delete(self.marmotta.ldp(encoder.encode(id)))
+    def del_collection(self, c_id):
+        if self.sparql.ask(self.marmotta.ldp(encoder.encode(c_id)), self.RDA.ns.Collection).askAnswer:
+            self.sparql.delete(self.marmotta.ldp(encoder.encode(c_id)))
             return True
         else:
             raise NotFoundError()
@@ -101,19 +101,19 @@ class LDPDataBase(DBInterface):
 
 
 
-    def get_member(self, cid, mid=None):
+    def get_member(self, c_id, m_id=None):
         # todo: ASK and check if member exists
-        if mid is not None:
-            if not isinstance(mid, list):
-                mid = [mid]
-            members = [self.marmotta.ldp(encoder.encode(cid)+"/member/"+encoder.encode(id)) for id in mid]
+        if m_id is not None:
+            if not isinstance(m_id, list):
+                m_id = [m_id]
+            members = [self.marmotta.ldp(encoder.encode(c_id)+"/member/"+encoder.encode(id)) for id in m_id]
             # ds = self.sparql.select(ids).toDataset()
             # contents = [self.RDA.graph_to_member(ds.graph(id)) for id in ids]
         else:
-            id = self.marmotta.ldp(encoder.encode(cid))
+            id = self.marmotta.ldp(encoder.encode(c_id))
             if not self.sparql.ask(id, self.RDA.ns.Collection).askAnswer:
                 raise NotFoundError
-            lst = self.sparql.list(s=self.marmotta.ldp(encoder.encode(cid)+"/member"), p=LDP.ns.contains)
+            lst = self.sparql.list(s=self.marmotta.ldp(encoder.encode(c_id)+"/member"), p=LDP.ns.contains)
             members = [dct[Variable('o')] for dct in lst.bindings]
         contents=[]
         if len(members):
@@ -121,18 +121,18 @@ class LDPDataBase(DBInterface):
             graphs = [dataset.graph(member) for member in members]
             for graph in graphs:
                 contents += self.RDA.graph_to_member(graph)
-        if mid is not None and len(contents) is 0:
+        if m_id is not None and len(contents) is 0:
             raise NotFoundError()
         return contents
 
-    def set_member(self, cid, m_obj):
+    def set_member(self, c_id, m_obj):
         if isinstance(m_obj, Model):
             m_obj = [m_obj]
         elif not isinstance(m_obj, list):
             raise ParseError()
 
-        c_id = self.marmotta.ldp(encoder.encode(cid))
-        collection = self.get_collection(cid).pop() # 404 if collection not found
+        c_ldp_id = self.marmotta.ldp(encoder.encode(c_id))
+        collection = self.get_collection(c_id).pop() # 404 if collection not found
 
         if len(set([m.id for m in m_obj])) is not len(m_obj):
             raise ForbiddenError()
@@ -143,45 +143,45 @@ class LDPDataBase(DBInterface):
                 if not(hasattr(m,"datatype") and m.datatype in collection.capabilities.restrictedToType):
                     raise ForbiddenError()
         if collection.capabilities.maxLength >= 0:
-            size = self.sparql.size(c_id).bindings.pop().get(Variable('size'))
+            size = self.sparql.size(c_ldp_id).bindings.pop().get(Variable('size'))
             if int(size) > collection.capabilities.maxLength-len(m_obj):
                 raise ForbiddenError()#"Operation forbidden. Collection of maximum size {} is full.".format(collection.capabilities.maxLength))
 
         ds = Dataset()
         ldp = ds.graph(identifier=LDP.ns)
         for m in m_obj:
-            m_id = self.marmotta.ldp(encoder.encode(cid)+"/member/"+encoder.encode(m.id))
+            m_id = self.marmotta.ldp(encoder.encode(c_id)+"/member/"+encoder.encode(m.id))
             member = ds.graph(identifier=m_id)
-            member += self.RDA.member_to_graph(cid,m)
-            ldp += LDP.add_contains(c_id+"/member",m_id,False)
+            member += self.RDA.member_to_graph(c_id,m)
+            ldp += LDP.add_contains(c_ldp_id+"/member",m_id,False)
         res = self.sparql.insert(ds)
         if res.status_code is not 200:
             raise DBError()
         return m_obj
 
-    def del_member(self, cid, mid):
-        collection = self.get_collection(cid).pop() # 404 if collection not found
+    def del_member(self, c_id, m_id):
+        collection = self.get_collection(c_id).pop() # 404 if collection not found
         if not collection.capabilities.membershipIsMutable:
             raise ForbiddenError()
-        id = self.marmotta.ldp(encoder.encode(cid)+"/member/"+encoder.encode(mid))
+        id = self.marmotta.ldp(encoder.encode(c_id)+"/member/"+encoder.encode(m_id))
         if self.sparql.ask(id, self.RDA.ns.Member).askAnswer:
             self.sparql.delete(id)
             return True
         else:
             raise NotFoundError()
 
-    def upd_member(self, cid, m_obj):
+    def upd_member(self, c_id, m_obj):
         # todo: needs a rewrite to be able to update when !membershipIsMutable
-        self.del_member(cid, m_obj.id)
-        self.set_member(cid, m_obj)
+        self.del_member(c_id, m_obj.id)
+        self.set_member(c_id, m_obj)
         return m_obj
 
-    def ask_member(self, cid, mid):
-        if not isinstance(mid, list):
-            mid = [mid]
-        ids = [self.marmotta.ldp(encoder.encode(cid)+"/member/"+encoder.encode(m)) for m in mid]
+    def ask_member(self, c_id, m_id):
+        if not isinstance(m_id, list):
+            m_id = [m_id]
+        ids = [self.marmotta.ldp(encoder.encode(c_id)+"/member/"+encoder.encode(m)) for m in m_id]
         result = self.sparql.find(ids,self.RDA.ns.Member)
-        return float(result.bindings.pop().get(Variable('size')))/len(mid)
+        return float(result.bindings.pop().get(Variable('size')))/len(m_id)
 
 
 
@@ -226,10 +226,10 @@ class LDPDataBase(DBInterface):
 
 
 
-    def get_id(self, type):
+    def get_id(self, type_class):
         id = ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(10, 30)))
-        if type is CollectionObject:
+        if type_class is CollectionObject:
             id = "urn:cite:test_collections."+id
-        if type is MemberItem:
+        if type_class is MemberItem:
             id = "urn:cite:test_members."+id
         return id

--- a/src/utils/data/ldp_db.py
+++ b/src/utils/data/ldp_db.py
@@ -21,7 +21,7 @@ class LDPDataBase(DBInterface):
 
     def __init__(self, server):
         self.marmotta = Marmotta(server)
-        self.sparql = SPARQLTools()
+        self.sparql = SPARQLTools(self.marmotta.sparql)
         self.RDA = RDATools(self.marmotta)
 
     def get_collection(self, id=None):

--- a/src/utils/data/ldp_db.py
+++ b/src/utils/data/ldp_db.py
@@ -24,6 +24,20 @@ class LDPDataBase(DBInterface):
         self.sparql = SPARQLTools(self.marmotta.sparql)
         self.RDA = RDATools(self.marmotta)
 
+    def find_collection(self, cid):
+        if not isinstance(cid, list):
+            cid = [cid]
+        ids = [self.marmotta.ldp(encoder.encode(id)) for id in cid]
+        result = self.sparql.find(ids,self.RDA.ns.Collection)
+        return float(result.bindings.pop().get(Variable('size')))/len(cid)
+
+    def find_member(self, cid, mid):
+        if not isinstance(mid, list):
+            mid = [mid]
+        ids = [self.marmotta.ldp(encoder.encode(cid)+"/member/"+encoder.encode(m)) for m in mid]
+        result = self.sparql.find(ids,self.RDA.ns.Member)
+        return float(result.bindings.pop().get(Variable('size')))/len(mid)
+
     def get_collection(self, id=None):
         # todo: ASK and check if collection exists
         if id is not None:

--- a/src/utils/data/null_db.py
+++ b/src/utils/data/null_db.py
@@ -3,25 +3,25 @@ from .db import DBInterface
 
 class NullDB(DBInterface):
 
-    def ask_collection(self, id):
+    def ask_collection(self, c_id):
         return 0
 
-    def ask_member(self, cid, mid):
+    def ask_member(self, c_id, m_id):
         return 0
 
-    def get_collection(self, id=None):
+    def get_collection(self, c_id=None):
         return []
 
     def set_collection(self, c_obj):
         return c_obj
 
-    def del_collection(self, id):
+    def del_collection(self, c_id):
         return []
 
     def upd_collection(self, c_obj):
         return c_obj
 
-    def get_member(self, id=None):
+    def get_member(self, c_id, m_id=None):
         return []
 
     def set_member(self, c_id, m_obj):
@@ -30,7 +30,7 @@ class NullDB(DBInterface):
     def del_member(self, c_id, m_id):
         return []
 
-    def upd_member(self, cid, m_obj):
+    def upd_member(self, c_id, m_obj):
         return m_obj
 
     def get_service(self):
@@ -39,5 +39,5 @@ class NullDB(DBInterface):
     def set_service(self, s_obj):
         return s_obj
 
-    def get_id(self, type):
+    def get_id(self, type_class):
         return ""

--- a/src/utils/data/null_db.py
+++ b/src/utils/data/null_db.py
@@ -3,6 +3,12 @@ from .db import DBInterface
 
 class NullDB(DBInterface):
 
+    def ask_collection(self, id):
+        return 0
+
+    def ask_member(self, cid, mid):
+        return 0
+
     def get_collection(self, id=None):
         return []
 

--- a/src/utils/rdf/queries.py
+++ b/src/utils/rdf/queries.py
@@ -1,17 +1,17 @@
 reset_marmotta = """
-DELETE {?s ?p ?o}
+DELETE {GRAPH ?g { ?s ?p ?o }}
 INSERT {
   GRAPH <http://www.w3.org/ns/ldp#> {
-    <http://localhost:32768/marmotta/ldp> <http://www.w3.org/2000/01/rdf-schema#label> "Marmotta's LDP Root Container" .
-    <http://localhost:32768/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Resource> .
-    <http://localhost:32768/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
-    <http://localhost:32768/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
-    <http://localhost:32768/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#BasicContainer> .
-    <http://localhost:32768/marmotta/ldp> <http://www.w3.org/ns/ldp#interactionModel> <http://www.w3.org/ns/ldp#Container> .
-    <http://localhost:32768/marmotta/ldp> <http://purl.org/dc/terms/created> "2017-03-15T13:41:19.000Z" .
-    <http://localhost:32768/marmotta/ldp> <http://purl.org/dc/terms/modified> "2017-04-19T16:35:31.000Z"
+    <http://localhost:8080/marmotta/ldp> <http://www.w3.org/2000/01/rdf-schema#label> "Marmotta's LDP Root Container" .
+    <http://localhost:8080/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Resource> .
+    <http://localhost:8080/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#RDFSource> .
+    <http://localhost:8080/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#Container> .
+    <http://localhost:8080/marmotta/ldp> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#BasicContainer> .
+    <http://localhost:8080/marmotta/ldp> <http://www.w3.org/ns/ldp#interactionModel> <http://www.w3.org/ns/ldp#Container> .
+    <http://localhost:8080/marmotta/ldp> <http://purl.org/dc/terms/created> "2017-03-15T13:41:19.000Z" .
+    <http://localhost:8080/marmotta/ldp> <http://purl.org/dc/terms/modified> "2017-04-19T16:35:31.000Z"
   }
-  GRAPH <http://localhost:32768/marmotta/context/cache> {
+  GRAPH <http://localhost:8080/marmotta/context/cache> {
     <http://www.w3.org/ns/ldp#> <http://purl.org/dc/terms/created> "2015-02-26" .
     <http://www.w3.org/ns/ldp#> <http://purl.org/dc/terms/description> "Vocabulary URIs defined in the Linked Data Platform (LDP) namespace." .
     <http://www.w3.org/ns/ldp#> <http://purl.org/dc/terms/publisher> <http://www.w3.org/data#W3C> .
@@ -29,4 +29,3 @@ INSERT {
   }
 } WHERE {?s ?p ?o}
 """
-

--- a/src/utils/rdf/sparql.py
+++ b/src/utils/rdf/sparql.py
@@ -103,5 +103,55 @@ class SPARQLTools:
             finally:
                 return SPARQLSet(json, response.status_code)
 
+    def list(self, g=None, s=None, p=None, o=None):
+        if not (g or s or p or o):
+            raise DBError()
+        query=self.queries.list(g,s,p,o)
+        return self.request(query, self.server.select)
+
+    def select(self, ids):
+        if not isinstance(ids, list):
+            ids = [ids]
+        for id in ids:
+            if not isinstance(id, URIRef):
+                raise DBError()
+        query = self.queries.select(ids)
+        return self.request(query, self.server.select)
+
+    def insert(self, dataset):
+        if not isinstance(dataset, Dataset):
+            raise DBError()
+        query = self.queries.insert(dataset)
+        return self.request(query, self.server.update)
+
+    def delete(self, id):
+        if not isinstance(id, URIRef):
+            raise DBError()
+        query = self.queries.delete(id)
+        return self.request(query, self.server.update)
+
+    def ask(self, id, type):
+        if not isinstance(id, URIRef):
+            raise DBError()
+        query = self.queries.ask(id, type)
+        return self.request(query, self.server.select)
+
+    def size(self, id):
+        if not isinstance(id, URIRef):
+            raise DBError()
+        query = self.queries.size(id)
+        return self.request(query, self.server.select)
+
+    def find(self, ids, type):
+        if not isinstance(ids, list):
+            ids = [ids]
+        for id in ids:
+            if not isinstance(id, URIRef):
+                raise DBError()
+        if not isinstance(type, URIRef):
+            raise DBError()
+        query = self.queries.find(ids, type)
+        return self.request(query, self.server.select)
+
     def result_to_dataset(self, result):
         return result_to_dataset(result)

--- a/src/utils/rdf/sparql.py
+++ b/src/utils/rdf/sparql.py
@@ -6,15 +6,11 @@ from src.utils.base.struct import Struct
 # todo: the queries could be consolidated into a single set with a few more parameters
 # todo: it's cleaner architecture but more complex interface - do it anyways?
 
-class SPARQLSet:
-
-    def __init__(self, list=None, select=None, delete=None, insert=None, update=None, ask=None):
-        self.list = list
-        self.select = select
-        self.delete = delete
-        self.insert = insert
-        self.update = update
-        self.ask = ask
+def result_to_dataset(result):
+    ds = Dataset()
+    for q in result.bindings:
+        ds.add((q[Variable('s')],q[Variable('p')],q[Variable('o')],q[Variable('g')]))
+    return ds
 
 class SPARQLTools:
 
@@ -82,7 +78,4 @@ class SPARQLTools:
         )
 
     def result_to_dataset(self, result):
-        ds = Dataset()
-        for q in result.bindings:
-            ds.add((q[Variable('s')],q[Variable('p')],q[Variable('o')],q[Variable('g')]))
-        return ds
+        return result_to_dataset(result)

--- a/src/utils/rdf/sparql.py
+++ b/src/utils/rdf/sparql.py
@@ -1,5 +1,5 @@
 from rdflib import URIRef, Dataset, Variable
-
+from rdflib.plugins.sparql.results.jsonresults import JSONResult
 from src.utils.base.struct import Struct
 
 
@@ -11,6 +11,15 @@ def result_to_dataset(result):
     for q in result.bindings:
         ds.add((q[Variable('s')],q[Variable('p')],q[Variable('o')],q[Variable('g')]))
     return ds
+
+class SPARQLSet(JSONResult):
+
+    def __init__(self, json, status_code):
+        super().__init__(json)
+        self.status_code = status_code
+
+    def toDataset(self):
+        return result_to_dataset(self)
 
 class SPARQLTools:
 

--- a/src/utils/rdf/sparql.py
+++ b/src/utils/rdf/sparql.py
@@ -18,37 +18,62 @@ class SPARQLSet:
 
 class SPARQLTools:
 
-    def __init__(self):
-        self.collections=Struct(
-            list=lambda g=None, s=None, p=None, o=None: "SELECT ?g ?s ?p ?o WHERE {{ {} GRAPH ?g {{ ?s ?p ?o }} }}".format(" ".join(["BIND ({} as ?{})".format(v.n3(),k) for k,v in {"g":g, "s":s, "p":p, "o":o}.items() if v is not None])).encode(),
-            delete=lambda id: 'DELETE {{GRAPH ?grph {{?sub ?pred ?obj}} }} WHERE {{ BIND("^{}(/member|$).*" AS ?pattern) GRAPH ?grph {{ ?sub ?pred ?obj }} FILTER(REGEX(STR(?grph), ?pattern) || REGEX(STR(?sub), ?pattern) || REGEX(STR(?obj), ?pattern)) }}'.format(id).encode(),
-            selects=lambda ids: '''SELECT ?g ?s ?p ?o WHERE {{
+    def __init__(self, server):
+        self.server = server
+        self.queries=Struct(
+            # todo: same
+            list=lambda g=None, s=None, p=None, o=None: '''
+                SELECT ?g ?s ?p ?o WHERE {{
+                {}
+                GRAPH ?g {{ ?s ?p ?o }}
+                }}
+            '''.format('\n'.join(['BIND ({} as ?{})'.format(v.n3(),k) for k,v in {'g':g, 's':s, 'p':p, 'o':o}.items() if v is not None])).encode(),
+            # todo: pattern same
+            delete=lambda id: '''
+                DELETE {{GRAPH ?grph {{?sub ?pred ?obj}} }} WHERE {{
+                BIND("^{}(/member|$).*" AS ?pattern)
+                GRAPH ?grph {{ ?sub ?pred ?obj }}
+                FILTER(REGEX(STR(?grph), ?pattern) || REGEX(STR(?sub), ?pattern) || REGEX(STR(?obj), ?pattern))
+                }}
+            '''.format(id).encode(),
+            # todo: same
+            select=lambda ids: '''
+                SELECT ?g ?s ?p ?o WHERE {{
                 values ?g {{ {} }}
-                GRAPH ?g {{ ?s ?p ?o }} }}
+                GRAPH ?g {{ ?s ?p ?o }}
+                }}
             '''.format(' '.join([i.n3() for i in ids])).encode(),
-            select=lambda id: 'SELECT ?g ?s ?p ?o WHERE {{ BIND("^{}($|/member.*)" AS ?pattern) GRAPH ?g {{ ?s ?p ?o }} FILTER(REGEX(STR(?g), ?pattern) || REGEX(STR(?s), ?pattern) || REGEX(STR(?o), ?pattern)) }}'.format(id).encode(),
-            insert=lambda dataset: 'INSERT DATA {{ {} }}'.format('\n'.join(['GRAPH {} {{ {} }}'.format(g.identifier.n3(), '\n'.join(['{} {} {} .'.format(t[0].n3(),t[1].n3(),t[2].n3()) for t in g.triples((None,None,None))])) for g in dataset.graphs() if not g.identifier==URIRef('urn:x-rdflib:default')])).encode(),
-            update=lambda dataset: [
-                'DELETE {{GRAPH ?grph {{?sub ?pred ?obj}} }} WHERE {{ BIND("^{}$" AS ?pattern) GRAPH ?grph {{ ?sub ?pred ?obj }} FILTER(REGEX(STR(?grph), ?pattern) || REGEX(STR(?sub), ?pattern) || REGEX(STR(?obj), ?pattern)) }}'.format(id).encode(),
-                'INSERT DATA {{ {} }}'.format('\n'.join(['GRAPH {} {{ {} }}'.format(g.identifier.n3(), '\n'.join(['{} {} {} .'.format(t[0].n3(),t[1].n3(),t[2].n3()) for t in g.triples((None,None,None))])) for g in dataset.graphs() if not g.identifier==URIRef('urn:x-rdflib:default')])).encode()
-            ],
-            ask=lambda id: 'ASK WHERE {{ {} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rd-alliance.org/ns/collections#Collection> }}'.format(id.n3()).encode(),
-            size=lambda id: 'SELECT (COUNT(?x) AS ?size) WHERE {{ <{}/member> <http://www.w3.org/ns/ldp#contains> ?x }}'.format(str(id)).encode()
-        )
-        self.members=Struct(
-            list=lambda g=None, s=None, p=None, o=None: "SELECT ?g ?s ?p ?o WHERE {{ {} GRAPH ?g {{ ?s ?p ?o }} }}".format(" ".join(["BIND ({} as ?{})".format(v.n3(),k) for k,v in {"g":g, "s":s, "p":p, "o":o}.items() if v is not None])).encode(),
-            delete=lambda id: 'DELETE {{GRAPH ?grph {{?sub ?pred ?obj}} }} WHERE {{ BIND("^{}$" AS ?pattern) GRAPH ?grph {{ ?sub ?pred ?obj }} FILTER(REGEX(STR(?grph), ?pattern) || REGEX(STR(?sub), ?pattern) || REGEX(STR(?obj), ?pattern)) }}'.format(id).encode(),
-            selects=lambda ids: '''SELECT ?g ?s ?p ?o WHERE {{
-                values ?g {{ {} }}
-                GRAPH ?g {{ ?s ?p ?o }} }}
-            '''.format(' '.join([i.n3() for i in ids])).encode(),
-            select=lambda id: 'SELECT ?g ?s ?p ?o WHERE {{ BIND("^{}$" AS ?pattern) GRAPH ?g {{ ?s ?p ?o }} FILTER(REGEX(STR(?g), ?pattern) || REGEX(STR(?s), ?pattern) || REGEX(STR(?o), ?pattern)) }}'.format(id).encode(),
-            insert=lambda dataset: 'INSERT DATA {{ {} }}'.format('\n'.join(['GRAPH {} {{ {} }}'.format(g.identifier.n3(), '\n'.join(['{} {} {} .'.format(t[0].n3(),t[1].n3(),t[2].n3()) for t in g.triples((None,None,None))])) for g in dataset.graphs() if not g.identifier==URIRef('urn:x-rdflib:default')])).encode(),
-            update=lambda dataset: [
-                'DELETE {{GRAPH ?grph {{?sub ?pred ?obj}} }} WHERE {{ BIND("^{}$" AS ?pattern) GRAPH ?grph {{ ?sub ?pred ?obj }} FILTER(REGEX(STR(?grph), ?pattern) || REGEX(STR(?sub), ?pattern) || REGEX(STR(?obj), ?pattern)) }}'.format(id).encode(),
-                'INSERT DATA {{ {} }}'.format('\n'.join(['GRAPH {} {{ {} }}'.format(g.identifier.n3(), '\n'.join(['{} {} {} .'.format(t[0].n3(),t[1].n3(),t[2].n3()) for t in g.triples((None,None,None))])) for g in dataset.graphs() if not g.identifier==URIRef('urn:x-rdflib:default')])).encode()
-            ],
-            ask=lambda id: 'ASK WHERE {{ {} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rd-alliance.org/ns/collections#Member> }}'.format(id.n3()).encode()
+            # todo: remove?
+            selectddd=lambda id: '''SELECT ?g ?s ?p ?o WHERE {{
+                BIND("^{}($|/member.*)" AS ?pattern)
+                GRAPH ?g {{ ?s ?p ?o }}
+                FILTER(REGEX(STR(?g), ?pattern) || REGEX(STR(?s), ?pattern) || REGEX(STR(?o), ?pattern))
+                }}
+            '''.format(id).encode(),
+            # todo: same
+            insert=lambda dataset: '''
+                INSERT DATA {{ {} }}
+            '''.format('\n'.join(['GRAPH {} {{ {} }}'.format(g.identifier.n3(), '\n'.join(['{} {} {} .'.format(t[0].n3(),t[1].n3(),t[2].n3()) for t in g.triples((None,None,None))])) for g in dataset.graphs() if not g.identifier==URIRef('urn:x-rdflib:default')])).encode(),
+            # todo: different classes
+            ask=lambda id, type: '''
+                ASK WHERE {{
+                {} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> {}
+                }}
+            '''.format(id.n3(), type.n3()).encode(),
+            # todo: specific to collections
+            size=lambda id: '''
+                SELECT (COUNT(?x) AS ?size) WHERE {{
+                <{}/member> <http://www.w3.org/ns/ldp#contains> ?x
+                }}
+            '''.format(str(id)).encode(),
+            # todo: class should be either Member or Collection
+            find=lambda ids, type=URIRef("http://www.w3.org/ns/ldp#Container"): '''
+                SELECT (COUNT(?x) AS ?size) WHERE {{
+                values ?x {{ {} }}
+                ?x <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> {} .
+                }}
+            '''.format(' '.join([id.n3() for id in ids]), type.n3()).encode(),
+            asky=lambda id: 'ASK WHERE {{ {} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rd-alliance.org/ns/collections#Member> }}'.format(id.n3()).encode()
         )
         self.service=Struct(
             select=lambda id: 'SELECT ?g ?s ?p ?o WHERE {{ BIND( {} AS ?s ) GRAPH ?g {{ ?s ?p ?o }} }}'.format(id.n3()).encode(),

--- a/test/conversions/rda.py
+++ b/test/conversions/rda.py
@@ -10,6 +10,7 @@ from test.mock import RandomGenerator
 class RDATestCase(unittest.TestCase):
 
     def setUp(self):
+        #self.maxDiff = None
         self.mock = RandomGenerator()
         self.rda = RDATools(Marmotta("http://localhost:8080/marmotta/"))
 

--- a/test/db/db_tests.py
+++ b/test/db/db_tests.py
@@ -1,138 +1,138 @@
-# import os
-# from random import randint
-# from tempfile import TemporaryDirectory
-# from unittest import TestCase, main
-#
-# from flask import json
-#
-# from run import app
-# from src.utils.data.filesystem_db import FilesystemDB
-# from src.utils.base.errors import NotFoundError
-# from test.mock import RandomGenerator
-#
-#
-# class DbTests(TestCase):
-#
-#     @classmethod
-#     def setUpClass(cls):
-#         print("\n// Test Filesystem DB ------------------")
-#
-#     def setUp(self):
-#         self.dir = TemporaryDirectory(dir=os.environ.get('COLLECTIONS_API_TEST_DIR','test/data'))
-#         #self.dir = mkdtemp(dir='./test/data')
-#         self.db = FilesystemDB(self.dir.name)
-#         self.mock = RandomGenerator()
-#
-#     def tearDown(self):
-#         # a = 'b'
-#         self.dir.cleanup()
-#
-#     def test_db_create_collection_on_filesystem(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             self.db.set_collection(c_obj)
-#             self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), self.db.d_collection)))
-#
-#     def test_db_access_created_collection(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             self.db.set_collection(c_obj)
-#             self.assertEqual(json.dumps(c_obj), json.dumps(self.db.get_collection(c_obj.id).pop()))
-#
-#     def test_db_access_multiple_collections(self):
-#         with app.app_context():
-#             c_objs = [self.mock.collection() for _ in range(randint(2, 5))]
-#             for c in c_objs:
-#                 self.db.set_collection(c)
-#             self.assertSetEqual(set([json.dumps(c) for c in c_objs]), set([json.dumps(c) for c in self.db.get_collection()]))
-#
-#     def test_db_delete_created_collection(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             self.db.set_collection(c_obj)
-#             self.db.del_collection(c_obj.id)
-#             self.assertFalse(os.path.isfile(os.path.join(self.db.d_data, c_obj.id, self.db.d_collection)))
-#
-#     def test_db_overwrite_collection(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             d_obj = self.mock.collection()
-#             d_obj.id = c_obj.id
-#             d_obj.capabilities.isOrdered = not c_obj.capabilities.isOrdered
-#             self.db.set_collection(c_obj)
-#             self.assertNotEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
-#             self.db.set_collection(d_obj)
-#             self.assertEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
-#
-#     def test_db_create_member_on_filesystem(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             m_obj = self.mock.member()
-#             self.db.set_collection(c_obj)
-#             self.db.set_member(c_obj.id, m_obj)
-#             self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), m_obj.id.replace('/', '∕')+'.json')))
-#
-#     def test_db_access_created_member(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             m_obj = self.mock.member()
-#             self.db.set_collection(c_obj)
-#             self.db.set_member(c_obj.id, m_obj)
-#             self.assertEqual(json.dumps(m_obj), json.dumps(self.db.get_member(c_obj.id, m_obj.id).pop()))
-#
-#     def test_db_access_multiple_members(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             self.db.set_collection(c_obj)
-#             m_objs = [self.mock.member() for _ in range(randint(2, 5))]
-#             for m_obj in m_objs:
-#                 self.db.set_member(c_obj.id, m_obj)
-#             self.assertSetEqual(set([json.dumps(m) for m in m_objs]), set([json.dumps(m) for m in self.db.get_member(c_obj.id)]))
-#
-#     def test_db_delete_created_member(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             m_obj = self.mock.member()
-#             self.db.set_collection(c_obj)
-#             self.db.set_member(c_obj.id, m_obj)
-#             self.assertTrue(len(self.db.get_member(c_obj.id, m_obj.id)) == 1)
-#             self.db.del_member(c_obj.id, m_obj.id)
-#             with self.assertRaises(NotFoundError) as context:
-#                 self.db.get_member(c_obj.id, m_obj.id)
-#
-#     def test_db_overwrite_member(self):
-#         with app.app_context():
-#             c_obj = self.mock.collection()
-#             m_obj = self.mock.member()
-#             n_obj = self.mock.member()
-#             n_obj.id = m_obj.id
-#             n_obj.location = m_obj.location+"x"
-#             self.db.set_collection(c_obj)
-#             self.db.set_member(c_obj.id, m_obj)
-#             self.db.set_member(c_obj.id, n_obj)
-#             self.assertEqual(self.db.get_member(c_obj.id, m_obj.id)[0].location, n_obj.location)
-#
-#     def test_db_create_service_on_filesystem(self):
-#         with app.app_context():
-#             s_obj = self.mock.service()
-#             self.db.set_service(s_obj)
-#             self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, self.db.d_service)))
-#
-#     def test_db_access_created_service(self):
-#         with app.app_context():
-#             s_obj = self.mock.service()
-#             self.db.set_service(s_obj)
-#             t_obj = self.db.get_service()
-#             self.assertEqual(json.dumps(s_obj), json.dumps(t_obj))
-#
-#     def test_db_overwrite_service(self):
-#         with app.app_context():
-#             s_obj = self.mock.service()
-#             t_obj = self.mock.service()
-#             t_obj.providesCollectionPids = not s_obj.providesCollectionPids
-#             self.db.set_service(s_obj)
-#             self.db.set_service(t_obj)
-#             self.assertNotEqual(json.dumps(s_obj), json.dumps(self.db.get_service()))
-#
-# if __name__ == '__main__':
-#     main()
+import os
+from random import randint
+from tempfile import TemporaryDirectory
+from unittest import TestCase, main
+
+from flask import json
+
+from run import app
+from src.utils.data.filesystem_db import FilesystemDB
+from src.utils.base.errors import NotFoundError
+from test.mock import RandomGenerator
+
+
+class DbTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        print("\n// Test Filesystem DB ------------------")
+
+    def setUp(self):
+        self.dir = TemporaryDirectory(dir=os.environ.get('COLLECTIONS_API_TEST_DIR','test/data'))
+        #self.dir = mkdtemp(dir='./test/data')
+        self.db = FilesystemDB(self.dir.name)
+        self.mock = RandomGenerator()
+
+    def tearDown(self):
+        # a = 'b'
+        self.dir.cleanup()
+
+    def test_db_create_collection_on_filesystem(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            self.db.set_collection(c_obj)
+            self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), self.db.d_collection)))
+
+    def test_db_access_created_collection(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            self.db.set_collection(c_obj)
+            self.assertEqual(json.dumps(c_obj), json.dumps(self.db.get_collection(c_obj.id).pop()))
+
+    def test_db_access_multiple_collections(self):
+        with app.app_context():
+            c_objs = [self.mock.collection() for _ in range(randint(2, 5))]
+            for c in c_objs:
+                self.db.set_collection(c)
+            self.assertSetEqual(set([json.dumps(c) for c in c_objs]), set([json.dumps(c) for c in self.db.get_collection()]))
+
+    def test_db_delete_created_collection(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            self.db.set_collection(c_obj)
+            self.db.del_collection(c_obj.id)
+            self.assertFalse(os.path.isfile(os.path.join(self.db.d_data, c_obj.id, self.db.d_collection)))
+
+    def test_db_overwrite_collection(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            d_obj = self.mock.collection()
+            d_obj.id = c_obj.id
+            d_obj.capabilities.isOrdered = not c_obj.capabilities.isOrdered
+            self.db.set_collection(c_obj)
+            self.assertNotEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
+            self.db.set_collection(d_obj)
+            self.assertEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
+
+    def test_db_create_member_on_filesystem(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            m_obj = self.mock.member()
+            self.db.set_collection(c_obj)
+            self.db.set_member(c_obj.id, m_obj)
+            self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), m_obj.id.replace('/', '∕')+'.json')))
+
+    def test_db_access_created_member(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            m_obj = self.mock.member()
+            self.db.set_collection(c_obj)
+            self.db.set_member(c_obj.id, m_obj)
+            self.assertEqual(json.dumps(m_obj), json.dumps(self.db.get_member(c_obj.id, m_obj.id).pop()))
+
+    def test_db_access_multiple_members(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            self.db.set_collection(c_obj)
+            m_objs = [self.mock.member() for _ in range(randint(2, 5))]
+            for m_obj in m_objs:
+                self.db.set_member(c_obj.id, m_obj)
+            self.assertSetEqual(set([json.dumps(m) for m in m_objs]), set([json.dumps(m) for m in self.db.get_member(c_obj.id)]))
+
+    def test_db_delete_created_member(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            m_obj = self.mock.member()
+            self.db.set_collection(c_obj)
+            self.db.set_member(c_obj.id, m_obj)
+            self.assertTrue(len(self.db.get_member(c_obj.id, m_obj.id)) == 1)
+            self.db.del_member(c_obj.id, m_obj.id)
+            with self.assertRaises(NotFoundError) as context:
+                self.db.get_member(c_obj.id, m_obj.id)
+
+    def test_db_overwrite_member(self):
+        with app.app_context():
+            c_obj = self.mock.collection()
+            m_obj = self.mock.member()
+            n_obj = self.mock.member()
+            n_obj.id = m_obj.id
+            n_obj.location = m_obj.location+"x"
+            self.db.set_collection(c_obj)
+            self.db.set_member(c_obj.id, m_obj)
+            self.db.set_member(c_obj.id, n_obj)
+            self.assertEqual(self.db.get_member(c_obj.id, m_obj.id)[0].location, n_obj.location)
+
+    def test_db_create_service_on_filesystem(self):
+        with app.app_context():
+            s_obj = self.mock.service()
+            self.db.set_service(s_obj)
+            self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, self.db.d_service)))
+
+    def test_db_access_created_service(self):
+        with app.app_context():
+            s_obj = self.mock.service()
+            self.db.set_service(s_obj)
+            t_obj = self.db.get_service()
+            self.assertEqual(json.dumps(s_obj), json.dumps(t_obj))
+
+    def test_db_overwrite_service(self):
+        with app.app_context():
+            s_obj = self.mock.service()
+            t_obj = self.mock.service()
+            t_obj.providesCollectionPids = not s_obj.providesCollectionPids
+            self.db.set_service(s_obj)
+            self.db.set_service(t_obj)
+            self.assertNotEqual(json.dumps(s_obj), json.dumps(self.db.get_service()))
+
+if __name__ == '__main__':
+    main()

--- a/test/db/db_tests.py
+++ b/test/db/db_tests.py
@@ -1,138 +1,138 @@
-import os
-from random import randint
-from tempfile import TemporaryDirectory
-from unittest import TestCase, main
-
-from flask import json
-
-from run import app
-from src.utils.data.filesystem_db import FilesystemDB
-from src.utils.base.errors import NotFoundError
-from test.mock import RandomGenerator
-
-
-class DbTests(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        print("\n// Test Filesystem DB ------------------")
-
-    def setUp(self):
-        self.dir = TemporaryDirectory(dir=os.environ.get('COLLECTIONS_API_TEST_DIR','test/data'))
-        #self.dir = mkdtemp(dir='./test/data')
-        self.db = FilesystemDB(self.dir.name)
-        self.mock = RandomGenerator()
-
-    def tearDown(self):
-        # a = 'b'
-        self.dir.cleanup()
-
-    def test_db_create_collection_on_filesystem(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            self.db.set_collection(c_obj)
-            self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), self.db.d_collection)))
-
-    def test_db_access_created_collection(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            self.db.set_collection(c_obj)
-            self.assertEqual(json.dumps(c_obj), json.dumps(self.db.get_collection(c_obj.id).pop()))
-
-    def test_db_access_multiple_collections(self):
-        with app.app_context():
-            c_objs = [self.mock.collection() for _ in range(randint(2, 5))]
-            for c in c_objs:
-                self.db.set_collection(c)
-            self.assertSetEqual(set([json.dumps(c) for c in c_objs]), set([json.dumps(c) for c in self.db.get_collection()]))
-
-    def test_db_delete_created_collection(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            self.db.set_collection(c_obj)
-            self.db.del_collection(c_obj.id)
-            self.assertFalse(os.path.isfile(os.path.join(self.db.d_data, c_obj.id, self.db.d_collection)))
-
-    def test_db_overwrite_collection(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            d_obj = self.mock.collection()
-            d_obj.id = c_obj.id
-            d_obj.capabilities.isOrdered = not c_obj.capabilities.isOrdered
-            self.db.set_collection(c_obj)
-            self.assertNotEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
-            self.db.set_collection(d_obj)
-            self.assertEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
-
-    def test_db_create_member_on_filesystem(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            m_obj = self.mock.member()
-            self.db.set_collection(c_obj)
-            self.db.set_member(c_obj.id, m_obj)
-            self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), m_obj.id.replace('/', '∕')+'.json')))
-
-    def test_db_access_created_member(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            m_obj = self.mock.member()
-            self.db.set_collection(c_obj)
-            self.db.set_member(c_obj.id, m_obj)
-            self.assertEqual(json.dumps(m_obj), json.dumps(self.db.get_member(c_obj.id, m_obj.id).pop()))
-
-    def test_db_access_multiple_members(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            self.db.set_collection(c_obj)
-            m_objs = [self.mock.member() for _ in range(randint(2, 5))]
-            for m_obj in m_objs:
-                self.db.set_member(c_obj.id, m_obj)
-            self.assertSetEqual(set([json.dumps(m) for m in m_objs]), set([json.dumps(m) for m in self.db.get_member(c_obj.id)]))
-
-    def test_db_delete_created_member(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            m_obj = self.mock.member()
-            self.db.set_collection(c_obj)
-            self.db.set_member(c_obj.id, m_obj)
-            self.assertTrue(len(self.db.get_member(c_obj.id, m_obj.id)) == 1)
-            self.db.del_member(c_obj.id, m_obj.id)
-            with self.assertRaises(NotFoundError) as context:
-                self.db.get_member(c_obj.id, m_obj.id)
-
-    def test_db_overwrite_member(self):
-        with app.app_context():
-            c_obj = self.mock.collection()
-            m_obj = self.mock.member()
-            n_obj = self.mock.member()
-            n_obj.id = m_obj.id
-            n_obj.location = m_obj.location+"x"
-            self.db.set_collection(c_obj)
-            self.db.set_member(c_obj.id, m_obj)
-            self.db.set_member(c_obj.id, n_obj)
-            self.assertEqual(self.db.get_member(c_obj.id, m_obj.id)[0].location, n_obj.location)
-
-    def test_db_create_service_on_filesystem(self):
-        with app.app_context():
-            s_obj = self.mock.service()
-            self.db.set_service(s_obj)
-            self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, self.db.d_service)))
-
-    def test_db_access_created_service(self):
-        with app.app_context():
-            s_obj = self.mock.service()
-            self.db.set_service(s_obj)
-            t_obj = self.db.get_service()
-            self.assertEqual(json.dumps(s_obj), json.dumps(t_obj))
-
-    def test_db_overwrite_service(self):
-        with app.app_context():
-            s_obj = self.mock.service()
-            t_obj = self.mock.service()
-            t_obj.providesCollectionPids = not s_obj.providesCollectionPids
-            self.db.set_service(s_obj)
-            self.db.set_service(t_obj)
-            self.assertNotEqual(json.dumps(s_obj), json.dumps(self.db.get_service()))
-
-if __name__ == '__main__':
-    main()
+# import os
+# from random import randint
+# from tempfile import TemporaryDirectory
+# from unittest import TestCase, main
+#
+# from flask import json
+#
+# from run import app
+# from src.utils.data.filesystem_db import FilesystemDB
+# from src.utils.base.errors import NotFoundError
+# from test.mock import RandomGenerator
+#
+#
+# class DbTests(TestCase):
+#
+#     @classmethod
+#     def setUpClass(cls):
+#         print("\n// Test Filesystem DB ------------------")
+#
+#     def setUp(self):
+#         self.dir = TemporaryDirectory(dir=os.environ.get('COLLECTIONS_API_TEST_DIR','test/data'))
+#         #self.dir = mkdtemp(dir='./test/data')
+#         self.db = FilesystemDB(self.dir.name)
+#         self.mock = RandomGenerator()
+#
+#     def tearDown(self):
+#         # a = 'b'
+#         self.dir.cleanup()
+#
+#     def test_db_create_collection_on_filesystem(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             self.db.set_collection(c_obj)
+#             self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), self.db.d_collection)))
+#
+#     def test_db_access_created_collection(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             self.db.set_collection(c_obj)
+#             self.assertEqual(json.dumps(c_obj), json.dumps(self.db.get_collection(c_obj.id).pop()))
+#
+#     def test_db_access_multiple_collections(self):
+#         with app.app_context():
+#             c_objs = [self.mock.collection() for _ in range(randint(2, 5))]
+#             for c in c_objs:
+#                 self.db.set_collection(c)
+#             self.assertSetEqual(set([json.dumps(c) for c in c_objs]), set([json.dumps(c) for c in self.db.get_collection()]))
+#
+#     def test_db_delete_created_collection(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             self.db.set_collection(c_obj)
+#             self.db.del_collection(c_obj.id)
+#             self.assertFalse(os.path.isfile(os.path.join(self.db.d_data, c_obj.id, self.db.d_collection)))
+#
+#     def test_db_overwrite_collection(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             d_obj = self.mock.collection()
+#             d_obj.id = c_obj.id
+#             d_obj.capabilities.isOrdered = not c_obj.capabilities.isOrdered
+#             self.db.set_collection(c_obj)
+#             self.assertNotEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
+#             self.db.set_collection(d_obj)
+#             self.assertEqual(self.db.get_collection(c_obj.id)[0].capabilities.isOrdered, d_obj.capabilities.isOrdered)
+#
+#     def test_db_create_member_on_filesystem(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             m_obj = self.mock.member()
+#             self.db.set_collection(c_obj)
+#             self.db.set_member(c_obj.id, m_obj)
+#             self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, c_obj.id.replace('/', '∕'), m_obj.id.replace('/', '∕')+'.json')))
+#
+#     def test_db_access_created_member(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             m_obj = self.mock.member()
+#             self.db.set_collection(c_obj)
+#             self.db.set_member(c_obj.id, m_obj)
+#             self.assertEqual(json.dumps(m_obj), json.dumps(self.db.get_member(c_obj.id, m_obj.id).pop()))
+#
+#     def test_db_access_multiple_members(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             self.db.set_collection(c_obj)
+#             m_objs = [self.mock.member() for _ in range(randint(2, 5))]
+#             for m_obj in m_objs:
+#                 self.db.set_member(c_obj.id, m_obj)
+#             self.assertSetEqual(set([json.dumps(m) for m in m_objs]), set([json.dumps(m) for m in self.db.get_member(c_obj.id)]))
+#
+#     def test_db_delete_created_member(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             m_obj = self.mock.member()
+#             self.db.set_collection(c_obj)
+#             self.db.set_member(c_obj.id, m_obj)
+#             self.assertTrue(len(self.db.get_member(c_obj.id, m_obj.id)) == 1)
+#             self.db.del_member(c_obj.id, m_obj.id)
+#             with self.assertRaises(NotFoundError) as context:
+#                 self.db.get_member(c_obj.id, m_obj.id)
+#
+#     def test_db_overwrite_member(self):
+#         with app.app_context():
+#             c_obj = self.mock.collection()
+#             m_obj = self.mock.member()
+#             n_obj = self.mock.member()
+#             n_obj.id = m_obj.id
+#             n_obj.location = m_obj.location+"x"
+#             self.db.set_collection(c_obj)
+#             self.db.set_member(c_obj.id, m_obj)
+#             self.db.set_member(c_obj.id, n_obj)
+#             self.assertEqual(self.db.get_member(c_obj.id, m_obj.id)[0].location, n_obj.location)
+#
+#     def test_db_create_service_on_filesystem(self):
+#         with app.app_context():
+#             s_obj = self.mock.service()
+#             self.db.set_service(s_obj)
+#             self.assertTrue(os.path.isfile(os.path.join(self.db.d_data, self.db.d_service)))
+#
+#     def test_db_access_created_service(self):
+#         with app.app_context():
+#             s_obj = self.mock.service()
+#             self.db.set_service(s_obj)
+#             t_obj = self.db.get_service()
+#             self.assertEqual(json.dumps(s_obj), json.dumps(t_obj))
+#
+#     def test_db_overwrite_service(self):
+#         with app.app_context():
+#             s_obj = self.mock.service()
+#             t_obj = self.mock.service()
+#             t_obj.providesCollectionPids = not s_obj.providesCollectionPids
+#             self.db.set_service(s_obj)
+#             self.db.set_service(t_obj)
+#             self.assertNotEqual(json.dumps(s_obj), json.dumps(self.db.get_service()))
+#
+# if __name__ == '__main__':
+#     main()

--- a/test/db/ldp_db_test.py
+++ b/test/db/ldp_db_test.py
@@ -26,59 +26,14 @@ class DbTests(TestCase):
         if not self.server:
             raise EnvironmentError
         self.db = LDPDataBase(self.server)
-        requests.post(self.db.marmotta.sparql.update, data=reset_marmotta)
+        res = requests.post(self.db.marmotta.sparql.update, data=reset_marmotta, headers={"Content-Type":"application/sparql-update; charset=utf-8"})
         self.mock = RandomGenerator()
 
     #def test_ldp_b64encode(self):
      #   self.assertEqual(self.db.b64encode(self.server),"aHR0cDovL2xvY2FsaG9zdDozMjc2OC9tYXJtb3R0YQ==")
 
     def tearDown(self):
-        requests.post(self.db.marmotta.sparql.update, data=reset_marmotta)
-
-    #def test_ldp_b64decode(self):
-    #    self.assertEqual(self.db.b64decode("aHR0cDovL2xvY2FsaG9zdDozMjc2OC9tYXJtb3R0YQ=="),self.server)
-
-    #def test_ldp_b64_roundtrip(self):
-    #    self.assertEqual(self.db.b64decode(self.db.b64encode(self.server)),self.server)
-
-    #def test_ldp_graph_to_dict(self):
-    #    self.db.graph_to_dict(graph, node, propertiesMap)
-
-    #def test_ldp_dict_to_graph(self):
-    #    assert False
-    #    self.db.dict_to_graph()
-
-    #def test_ldp_collection_to_graph(self):
-    #    assert False
-    #    self.db.collection_to_graph()
-
-    #def test_ldp_graph_to_collection(self):
-    #    assert False
-    #    self.db.graph_to_collection()
-
-    #def test_ldp_member_to_graph(self):
-    #    assert False
-    #    self.db.member_to_graph()
-
-    #def test_ldp_graph_to_member(self):
-    #    assert False
-    #    self.db.graph_to_member()
-
-    #def test_ldp_service_to_graph(self):
-    #    assert False
-    #    self.db.service_to_graph()
-
-    #def test_ldp_graph_to_service(self):
-    #    assert False
-    #    self.db.graph_to_service()
-
-    #def test_ldp_result_to_dataset(self):
-    #    assert False
-    #    self.db.result_to_dataset()
-
-    #def test_ldp_add_contains(self):
-    #    assert False
-    #    self.db.ldp_add_contains()
+        requests.post(self.db.marmotta.sparql.update, data=reset_marmotta, headers={"Content-Type":"application/sparql-update; charset=utf-8"})
 
     def test_ldp_create_collection(self):
         with app.app_context():
@@ -101,6 +56,7 @@ class DbTests(TestCase):
     def test_ldp_access_multiple_collections(self):
          with app.app_context():
              # todo: post collections to sparql, retrieve via LDP and compare
+             requests.post(self.db.marmotta.sparql.update, data=reset_marmotta)
              c_objs = [self.mock.collection() for _ in range(randint(2, 5))]
              for c in c_objs:
                  self.db.set_collection(c)

--- a/test/db/ldp_db_test.py
+++ b/test/db/ldp_db_test.py
@@ -40,9 +40,9 @@ class DbTests(TestCase):
             c_obj = self.mock.collection()
             id = self.db.marmotta.ldp(encoder.encode(c_obj.id))
             self.db.set_collection(c_obj)
-            response = requests.post(self.db.marmotta.sparql.select,data=self.db.sparql.collections.select(id),headers={"Accept":"application/sparql-results+json"})
+            response = self.db.sparql.select(id) # todo: figure out if using db.sparql or sparql
             #print(response.json())
-            r_obj = self.db.RDA.graph_to_collection(self.db.sparql.result_to_dataset(JSONResult(response.json())).graph(id)).pop()
+            r_obj = self.db.RDA.graph_to_collection(response.toDataset().graph(id)).pop()
             self.assertDictEqual(c_obj.dict(), r_obj.dict())
 
     def test_ldp_access_created_collection(self):
@@ -58,9 +58,10 @@ class DbTests(TestCase):
              # todo: post collections to sparql, retrieve via LDP and compare
              requests.post(self.db.marmotta.sparql.update, data=reset_marmotta)
              c_objs = [self.mock.collection() for _ in range(randint(2, 5))]
-             for c in c_objs:
-                 self.db.set_collection(c)
-             self.assertSetEqual(set([json.dumps(c) for c in c_objs]), set([json.dumps(c) for c in self.db.get_collection()]))
+             self.db.set_collection(c_objs)
+             set1 = set([json.dumps(c) for c in c_objs])
+             set2 = set([json.dumps(c) for c in self.db.get_collection()])
+             self.assertSetEqual(set1, set2)
 
     def test_ldp_access_with_ldp(self):
         with app.app_context():
@@ -97,8 +98,8 @@ class DbTests(TestCase):
              id = self.db.marmotta.ldp(encoder.encode(c_obj.id)+"/member/"+encoder.encode(m_obj.id))
              self.db.set_collection(c_obj)
              self.db.set_member(c_obj.id, m_obj)
-             response = requests.post(self.db.marmotta.sparql.select,data=self.db.sparql.members.select(id),headers={"Accept":"application/sparql-results+json"})
-             r_obj = self.db.RDA.graph_to_member(self.db.sparql.result_to_dataset(JSONResult(response.json())).graph(id)).pop()
+             response = self.db.sparql.select(id)
+             r_obj = self.db.RDA.graph_to_member(response.toDataset().graph(id)).pop()
              self.assertDictEqual(m_obj.dict(),r_obj.dict())
 
     def test_db_access_created_member(self):

--- a/test/mock.py
+++ b/test/mock.py
@@ -154,14 +154,12 @@ class RandomGenerator:
         node = URIRef(ldp_root+encoder.encode(obj.id))
         capabilities = URIRef(node+"#capabilities")
         properties = URIRef(node+"#properties")
-        description = URIRef(node+"#description")
 
         g = Graph(identifier=node)
         g.add((node, RDF.type, RDA.Collection))
         g.add((node, DCTERMS.identifier, Literal(obj.id)))
         g.add((node, RDA.hasCapabilities, capabilities))
         g.add((node, RDA.hasProperties, properties))
-        g.add((node, DCTERMS.description, description))
         g.add((capabilities, RDA.isOrdered, Literal(obj.capabilities.isOrdered)))
         g.add((capabilities, RDA.appendsToEnd, Literal(obj.capabilities.appendsToEnd)))
         g.add((capabilities, RDA.maxLength, Literal(obj.capabilities.maxLength)))
@@ -175,7 +173,13 @@ class RandomGenerator:
         g.add((properties, DCTERMS.license, Literal(obj.properties.license)))
         g.add((properties, DCTERMS.rightsHolder, URIRef(obj.properties.ownership)))
         g.add((properties, RDA.hasAccessRestrictions, Literal(obj.properties.hasAccessRestrictions)))
-        g.add((description, URIRef(description+"@something"), Literal(obj.description['something'])))
+        if hasattr(obj, "description") and isinstance(obj.description, dict):
+            description = URIRef(node+"#description")
+            g.add((node, DCTERMS.description, description))
+            if len(obj.description.items()) is 0:
+                g.add((description, RDF.type, RDA.Empty))
+            for key,value in obj.description.items():
+                g.add((description, URIRef(description+"@"+key), Literal(obj.description[key])))
         return g
 
     def graph_member(self, ldp_root, c_id, obj=None):

--- a/test/mock.py
+++ b/test/mock.py
@@ -16,35 +16,72 @@ LDP = ldp.ns
 
 class RandomGenerator:
 
-    def collection(self, id=None):
+    def collection(self,
+                   id=None,
+                   isOrdered=False,
+                   appendsToEnd=False,
+                   supportsRoles=True,
+                   membershipIsMutable=True,
+                   metatdataIsMutable=True,
+                   restrictedToType="",
+                   maxLength=-1,
+                   ownership="http://example.org/me",
+                   license="CCbySA",
+                   modelType="https://github.com/perseids-project/CITE-JSON-LD/blob/master/templates/img/SCHEMA.md",
+                   hasAccessRestrictions=False,
+                   memberOf=[],
+                   descriptionOntology="https://github.com/perseids-project/CITE-JSON-LD/blob/master/templates/img/SCHEMA.md",
+                   description={}):
         with app.app_context():
             id = id if id is not None else ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(10, 30)))
             return CollectionObject.apply({
                 "id": id,
                 "capabilities": CollectionCapabilities.apply({
-                    "isOrdered": random.choice([True, False]),
-                    "appendsToEnd": random.choice([True, False]),
-                    "supportsRoles": random.choice([True, False]),
-                    "membershipIsMutable": True,#random.choice([True, False]),
-                    "metadataIsMutable": True,#random.choice([True, False]),
-                    "restrictedToType": "",
-                    "maxLength": -1
+                    "isOrdered": isOrdered,
+                    "appendsToEnd": appendsToEnd,
+                    "supportsRoles": supportsRoles,
+                    "membershipIsMutable": membershipIsMutable,
+                    "metadataIsMutable": metatdataIsMutable,
+                    "restrictedToType": restrictedToType,
+                    "maxLength": maxLength
                 }),
                 "properties": CollectionProperties.apply({
-                    "ownership": "perseids:me",
-                    "license": "CCbySA",
-                    "modelType": "https://github.com/perseids-project/CITE-JSON-LD/blob/master/templates/img/SCHEMA.md",
-                    "hasAccessRestrictions": random.choice([True, False]),
-                    "memberOf": [],
-                    "descriptionOntology": "https://github.com/perseids-project/CITE-JSON-LD/blob/master/templates/img/SCHEMA.md"
+                    "ownership": ownership,
+                    "license": license,
+                    "modelType": modelType,
+                    "hasAccessRestrictions": hasAccessRestrictions,
+                    "memberOf": memberOf,
+                    "descriptionOntology": descriptionOntology
                 }),
-                "description": {'something': u''.join(random.choice(string.printable) for _ in range(random.randint(30, 50)))+"\u00f6"}#"\u00f6"}
+                "description": description
             })
 
-    def member(self, id=None):
-        return MemberItem(id if id is not None else ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(10, 30))),
-                          ''.join(random.choice(string.printable) for _ in range(random.randint(10, 30))),
-                          mappings=CollectionItemMappingMetadata(role="http://example.org/item", index=random.randint(1,9999), dateAdded=datetime.datetime.now().isoformat()))
+    def member(self,
+               id=None,
+               location=None,
+               datatype=None,
+               ontology=None,
+               role=None,
+               index=None,
+               dateAdded=None):
+        item = {
+            'id': id if id else ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(10, 30))),
+            'location': location if location else ''.join(random.choice(string.ascii_letters) for _ in range(random.randint(10, 30)))
+        }
+        if datatype:
+            item['datatype'] = datatype
+        if ontology:
+            item['ontology'] = ontology
+        if role or index or dateAdded:
+            mappings = {}
+            if role:
+                mappings['role'] = role
+            if index:
+                mappings['index'] = index
+            if dateAdded:
+                mappings['dateAdded'] = dateAdded
+            item['mappings'] = CollectionItemMappingMetadata(**mappings)
+        return MemberItem(**item)
 
     def service(self):
         return Service.apply({
@@ -136,7 +173,7 @@ class RandomGenerator:
         g.add((properties, RDA.modelType, Literal(obj.properties.modelType)))
         g.add((properties, RDA.descriptionOntology, Literal(obj.properties.descriptionOntology)))
         g.add((properties, DCTERMS.license, Literal(obj.properties.license)))
-        g.add((properties, DCTERMS.rightsHolder, Literal(obj.properties.ownership)))
+        g.add((properties, DCTERMS.rightsHolder, URIRef(obj.properties.ownership)))
         g.add((properties, RDA.hasAccessRestrictions, Literal(obj.properties.hasAccessRestrictions)))
         g.add((description, URIRef(description+"@something"), Literal(obj.description['something'])))
         return g

--- a/test/rdf/sparql.py
+++ b/test/rdf/sparql.py
@@ -1,8 +1,10 @@
+import os
 from unittest import TestCase
 from rdflib import Variable
 from rdflib.plugins.sparql.results.jsonresults import JSONResult
 
 from src.utils.rdf.sparql import SPARQLTools
+from src.utils.ids.marmotta import Marmotta
 from test.mock import RandomGenerator
 
 
@@ -10,7 +12,7 @@ class SPARQLTest(TestCase):
 
     def setUp(self):
         self.mock = RandomGenerator()
-        self.sparql = SPARQLTools()
+        self.sparql = SPARQLTools(Marmotta(os.environ.get('COLLECTIONS_API_TEST_DB')).sparql)
 
     def test_ldp_result_to_dataset(self):
         result = self.mock.collection_result()

--- a/test/routes/collection_tests.py
+++ b/test/routes/collection_tests.py
@@ -75,10 +75,10 @@ class CollectionTest(TestCase):
         with self.app.app_context():
             c_dicts = [self.mock.collection(description={'something':'abcdefghi123ö'}).dict() for i in range(5)]
             with self.app.test_client() as c:
-                results = [{'out': c.post("/collections", data=json.dumps(col), content_type='application/json', follow_redirects=True), 'in': col} for col in c_dicts]
+                results = [{'out': c.post("/collections", data=json.dumps([col]), content_type='application/json', follow_redirects=True), 'in': col} for col in c_dicts]
             for r in results:
                 self.assertEqual(r['out'].status_code, 201)
-                r_dict = json.loads(r['out'].data).dict()
+                r_dict = json.loads(r['out'].data).pop().dict()
                 self.assertEqual(json.dumps(r_dict), json.dumps(r['in']))
 
     def test_collection_delete_id(self):

--- a/test/routes/collection_tests.py
+++ b/test/routes/collection_tests.py
@@ -78,7 +78,7 @@ class CollectionTest(TestCase):
                 results = [{'out': c.post("/collections", data=json.dumps(col), content_type='application/json', follow_redirects=True), 'in': col} for col in c_dicts]
             for r in results:
                 self.assertEqual(r['out'].status_code, 201)
-                r_dict = json.loads(r['out'].data).__dict__
+                r_dict = json.loads(r['out'].data).dict()
                 self.assertEqual(json.dumps(r_dict), json.dumps(r['in']))
 
     def test_collection_delete_id(self):

--- a/test/routes/collection_tests.py
+++ b/test/routes/collection_tests.py
@@ -25,7 +25,7 @@ class CollectionTest(TestCase):
         if not self.server:
             raise EnvironmentError
         self.app.db = LDPDataBase(self.server)
-        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta)
+        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta, headers={"Content-Type":"application/sparql-update; charset=utf-8"})
         #self.dir = TemporaryDirectory(dir='test/data')
         # self.dir = mkdtemp(dir='test/data')
         #self.app.db = FilesystemDB(self.dir.name)
@@ -33,7 +33,7 @@ class CollectionTest(TestCase):
 
     def tearDown(self):
         #self.dir.cleanup()
-        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta)
+        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta, headers={"Content-Type":"application/sparql-update; charset=utf-8"})
 
     def to_dict(self, c_obj):
         if isinstance(c_obj, CollectionObject):

--- a/test/routes/collection_tests.py
+++ b/test/routes/collection_tests.py
@@ -48,7 +48,7 @@ class CollectionTest(TestCase):
 
     def test_collection_get(self):
         with self.app.app_context():
-            c_objs = [self.mock.collection() for i in range(5)]
+            c_objs = [self.mock.collection(description={'something':'abcdefghi123ö'}) for i in range(5)]
             for c in c_objs:
                 self.app.db.set_collection(c)
             response = self.get("/collections")
@@ -58,7 +58,7 @@ class CollectionTest(TestCase):
 
     def test_collection_get_id(self):
         with self.app.app_context():
-            c_objs = [self.mock.collection() for i in range(5)]
+            c_objs = [self.mock.collection(description={'something':'abcdefghi123ö'}) for i in range(5)]
             for c in c_objs:
                 self.app.db.set_collection(c)
             response = [self.get("/collections/"+urllib.parse.quote_plus(c.id)) for c in c_objs]
@@ -73,7 +73,7 @@ class CollectionTest(TestCase):
 
     def test_collection_post(self):
         with self.app.app_context():
-            c_dicts = [self.mock.collection().__dict__ for i in range(5)]
+            c_dicts = [self.mock.collection(description={'something':'abcdefghi123ö'}).dict() for i in range(5)]
             with self.app.test_client() as c:
                 results = [{'out': c.post("/collections", data=json.dumps(col), content_type='application/json', follow_redirects=True), 'in': col} for col in c_dicts]
             for r in results:
@@ -83,7 +83,7 @@ class CollectionTest(TestCase):
 
     def test_collection_delete_id(self):
         with self.app.app_context():
-            c_objs = [self.mock.collection() for i in range(5)]
+            c_objs = [self.mock.collection(description={'something':'abcdefghi123ö'}) for i in range(5)]
             for c in c_objs:
                 self.app.db.set_collection(c)
             with self.app.test_client() as c:
@@ -101,7 +101,7 @@ class CollectionTest(TestCase):
 
     def test_collection_put_id(self):
         with self.app.app_context():
-            c_objs = [self.mock.collection() for i in range(5)]
+            c_objs = [self.mock.collection(description={'something':'abcdefghi123ö'}) for i in range(5)]
             for c in c_objs:
                 self.app.db.set_collection(c)
                 c.description.update({"added_description":"changed"})
@@ -109,14 +109,14 @@ class CollectionTest(TestCase):
                 for col in c_objs:
                     response = c.put("/collections/"+urllib.parse.quote_plus(col.id), data=json.dumps(col), content_type="application/json", follow_redirects=True)
                     self.assertEqual(response.status_code, 200)
-                    self.assertEqual(json.dumps(json.loads(response.data)), json.dumps(col))
+                    self.assertEqual(json.dumps(json.loads(response.data)), json.dumps([col]))
                     response = self.get("/collections/"+urllib.parse.quote_plus(col.id))
                     self.assertEqual(response.status_code, 200)
                     self.assertEqual(json.dumps(json.loads(response.data)), json.dumps(col))
 
     def test_collection_put_unknown_id(self):
         with self.app.app_context():
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             with self.app.test_client() as c:
                 response = c.put("/collections/"+urllib.parse.quote_plus(c_obj.id), data=json.dumps(c_obj), content_type="application/json", follow_redirects=True)
                 self.assertEqual(response.status_code, 404)

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -130,6 +130,19 @@ class MembersTest(TestCase):
             for i in range(len(sortedMocks)):
                 self.assertEqual(sortedMocks[i]['location'], sortedResponse[i].location)
 
+    def test_members_post_array(self):
+        with self.app.app_context():
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
+            self.app.db.set_collection(c_obj)
+            m_dicts = [self.mock.member().dict() for i in range(5)]
+            self.assertListEqual(self.app.db.get_member(c_obj.id), [])
+            response = self.post("/collections/"+urllib.parse.quote_plus(c_obj.id)+"/members", json.dumps(m_dicts))
+            self.assertEqual(response.status_code, 201)
+            sortedResponse = sorted(json.loads(response.data), key=lambda x: x.location)
+            sortedMocks = sorted(m_dicts, key=lambda x: x['location'])
+            for i in range(len(sortedMocks)):
+                self.assertEqual(sortedMocks[i]['location'], sortedResponse[i].location)
+
     def test_members_post_too_many(self):
         with self.app.app_context():
             c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -75,8 +75,8 @@ class MembersTest(TestCase):
             m_objs = [self.mock.member() for i in range(5)]
             # add collection, members
             self.app.db.set_collection(c_obj)
-            for m_obj in m_objs:
-                self.app.db.set_member(c_obj.id, m_obj)
+            # for m_obj in m_objs:
+            self.app.db.set_member(c_obj.id, m_objs)
             # pool = ThreadPool(50)
             # pool.map(lambda m_obj: self.app.db.set_member(c_obj.id, m_obj), m_objs)
             # GET members

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -54,7 +54,7 @@ class MembersTest(TestCase):
     def test_members_get_id(self):
         with self.app.app_context():
             # create collection, members
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             m_objs = [self.mock.member() for i in range(5)]
             # add collection, members
             self.app.db.set_collection(c_obj)
@@ -71,7 +71,7 @@ class MembersTest(TestCase):
     def test_members_get(self):
         with self.app.app_context():
             # create collection, members
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             m_objs = [self.mock.member() for i in range(5)]
             # add collection, members
             self.app.db.set_collection(c_obj)
@@ -91,7 +91,7 @@ class MembersTest(TestCase):
     def test_member_recursive_get(self):
         with self.app.app_context():
             # create collection, members
-            c_objs = [self.mock.collection() for i in range(5)]
+            c_objs = [self.mock.collection(description={'something':'abcdefghi123ö'}) for i in range(5)]
             m_objs = {}
             for i in [0,1,2,3]:
                 m_objs.update({c_objs[i].id:[self.mock.member() for j in range(4)]+[self.mock.member(c_objs[i+1].id)]})
@@ -117,7 +117,7 @@ class MembersTest(TestCase):
 
     def test_members_post(self):
         with self.app.app_context():
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             self.app.db.set_collection(c_obj)
             m_dicts = [self.mock.member().__dict__ for i in range(5)]
             self.assertListEqual(self.app.db.get_member(c_obj.id), [])
@@ -131,7 +131,7 @@ class MembersTest(TestCase):
 
     def test_members_post_too_many(self):
         with self.app.app_context():
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             c_obj.capabilities.maxLength = 3
             self.app.db.set_collection(c_obj)
             m_dicts = [self.mock.member().__dict__ for i in range(5)]
@@ -140,7 +140,7 @@ class MembersTest(TestCase):
 
     def test_members_put_id(self):
         with self.app.app_context():
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             self.app.db.set_collection(c_obj)
             m_objs = [self.mock.member() for i in range(5)]
             for m_obj in m_objs:
@@ -157,7 +157,7 @@ class MembersTest(TestCase):
 
     def test_members_delete_id(self):
         with self.app.app_context():
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             self.app.db.set_collection(c_obj)
             m_objs = [self.mock.member() for i in range(5)]
             for m_obj in m_objs:
@@ -169,7 +169,7 @@ class MembersTest(TestCase):
 
     def test_members_delete_unknown_id(self):
         with self.app.app_context():
-            c_obj = self.mock.collection()
+            c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             self.app.db.set_collection(c_obj)
             m_obj = self.mock.member()
             response = self.delete("/collections/"+urllib.parse.quote_plus(c_obj.id)+"/members/"+urllib.parse.quote_plus(m_obj.id))

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -119,8 +119,9 @@ class MembersTest(TestCase):
         with self.app.app_context():
             c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})
             self.app.db.set_collection(c_obj)
-            m_dicts = [self.mock.member().__dict__ for i in range(5)]
+            m_dicts = [self.mock.member().dict() for i in range(5)]
             self.assertListEqual(self.app.db.get_member(c_obj.id), [])
+
             responses = [self.post("/collections/"+urllib.parse.quote_plus(c_obj.id)+"/members", json.dumps(m)) for m in m_dicts]
             for r in responses:
                 self.assertEqual(r.status_code, 201)

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -168,7 +168,6 @@ class MembersTest(TestCase):
                 self.assertEqual(m_obj.id, result.id)
                 self.assertNotEqual(m_obj.location, result.location)
 
-
     def test_members_delete_id(self):
         with self.app.app_context():
             c_obj = self.mock.collection(description={'something':'abcdefghi123ö'})

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -26,14 +26,14 @@ class MembersTest(TestCase):
         if not self.server:
             raise EnvironmentError
         self.app.db = LDPDataBase(self.server)
-        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta)
+        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta, headers={"Content-Type":"application/sparql-update; charset=utf-8"})
         #elf.dir = TemporaryDirectory(dir='test/data')
         #elf.app.db = FilesystemDB(self.dir.name)
         self.mock = RandomGenerator()
 
     def tearDown(self):
         #elf.dir.cleanup()
-        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta)
+        requests.post(self.app.db.marmotta.sparql.update, data=reset_marmotta, headers={"Content-Type":"application/sparql-update; charset=utf-8"})
 
     def get(self, path):
         with self.app.test_client() as client:

--- a/test/routes/member_tests.py
+++ b/test/routes/member_tests.py
@@ -75,9 +75,10 @@ class MembersTest(TestCase):
             m_objs = [self.mock.member() for i in range(5)]
             # add collection, members
             self.app.db.set_collection(c_obj)
-            pool = ThreadPool(50)
-            # for m_obj in m_objs:
-            pool.map(lambda m_obj: self.app.db.set_member(c_obj.id, m_obj), m_objs)
+            for m_obj in m_objs:
+                self.app.db.set_member(c_obj.id, m_obj)
+            # pool = ThreadPool(50)
+            # pool.map(lambda m_obj: self.app.db.set_member(c_obj.id, m_obj), m_objs)
             # GET members
             response = self.get("collections/"+urllib.parse.quote_plus(c_obj.id)+"/members")
             # assert 200 OK


### PR DESCRIPTION
Refactored parts of the LDP backend to support more streamlined and efficient SPARQL queries; enabled INSERTing and SELECTing of multiple items at once; propagated up to View/API; updated tests